### PR TITLE
Update MultipleImagePickerModule.kt

### DIFF
--- a/android/src/main/java/com/reactnativemultipleimagepicker/MultipleImagePickerModule.kt
+++ b/android/src/main/java/com/reactnativemultipleimagepicker/MultipleImagePickerModule.kt
@@ -218,7 +218,7 @@ class MultipleImagePickerModule(reactContext: ReactApplicationContext) : ReactCo
             fOut = FileOutputStream(file)
 
             // 100 means no compression, the lower you go, the stronger the compression
-            image.compress(Bitmap.CompressFormat.JPEG, 50, fOut)
+            image?.compress(Bitmap.CompressFormat.JPEG, 50, fOut)
             fOut.flush()
             fOut.close()
 


### PR DESCRIPTION
Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Bitmap? issue fixes