### PR TITLE
Fix error when clicking on photo preview (not circle) in android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,5 +131,6 @@ dependencies {
     exclude group: 'com.github.LuckSiege.PictureSelector', module: 'ucrop'
   }
   implementation 'com.github.bumptech.glide:glide:4.12.0'
+  compile 'com.yalantis:ucrop:2.2.0' // Fixes issue with clicking on the photos in the selector
   annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
 }


### PR DESCRIPTION
Resolves #9

Tested on Samsung Galaxy S10

Solution found via this issue https://github.com/q805699513/PhotoPicker/issues/7
and the README in the main library here: https://github.com/q805699513/PhotoPicker