### PR TITLE
fix: 🐛 fix `Multiple commands produce...` issue

### DIFF
--- a/react-native-multiple-image-picker.podspec
+++ b/react-native-multiple-image-picker.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift,lproj}"
 
   s.resource_bundles = { 'MultipleImagePicker' => ['ios/**/*.xib'] }
-  s.resources = 'ios/MultipleImagePicker.bundle'
+  #s.resources = 'ios/MultipleImagePicker.bundle'
 
   s.dependency 'React-Core'
   s.dependency 'TLPhotoPicker', '2.1.4'


### PR DESCRIPTION
I was getting an error from Xcode while running the app with the package installed:
```shell
✔ Installed pods and initialized Xcode workspace.
› Planning build

❌  error: Multiple commands produce '/Users/______/Library/Developer/Xcode/DerivedData/______-dsqsrgapxbjqamdwlxmfokevxuuy/Build/Products/Debug-iphonesimulator/react-native-multiple-image-picker/react_native_multiple_image_picker.framework/MultipleImagePicker.bundle':


    Capabilities for Signing & Capabilities may not function correctly because its entitlements use a placeholder team ID. To resolve this, select a development team in the ______ editor. (in target '______' from project '______')
    duplicate output file '/Users/______/Library/Developer/Xcode/DerivedData/______-dsqsrgapxbjqamdwlxmfokevxuuy/Build/Products/Debug-iphonesimulator/react-native-multiple-image-picker/react_native_multiple_image_picker.framework/MultipleImagePicker.bundle' on task: CpResource /Volumes/Programming/______/______/node_modules/@baronha/react-native-multiple-image-picker/ios/MultipleImagePicker.bundle /Users/______/Library/Developer/Xcode/DerivedData/______-dsqsrgapxbjqamdwlxmfokevxuuy/Build/Products/Debug-iphonesimulator/react-native-multiple-image-picker/react_native_multiple_image_picker.framework/MultipleImagePicker.bundle (in target 'react-native-multiple-image-picker' from project 'Pods')

› 1 error(s), and 2 warning(s)

Failed to build iOS project. "xcodebuild" exited with error code 65.
```

* I was able to run the app after removing the duplicate entry from "Copy Bundle Resources" under "Build Phases" from Pods.
* I made changes to the Podspec file to fix the manual work.