### PR TITLE
Fix - Deactivate Crop Controller when isCrop is false in Android

### DIFF
--- a/android/src/main/java/com/reactnativemultipleimagepicker/MultipleImagePickerModule.kt
+++ b/android/src/main/java/com/reactnativemultipleimagepicker/MultipleImagePickerModule.kt
@@ -127,6 +127,8 @@ class MultipleImagePickerModule(reactContext: ReactApplicationContext) :
 
             if (isCrop) {
                 setCropOptions(options)
+            } else {
+                cropOption = null
             }
         }
     }


### PR DESCRIPTION
If `isCrop` is set to `true`, the picker opens, and then another picker is opened with `isCrop` set to `false`, the cropper keeps appearing all the time on Android.