### PR TITLE
Fix the swift runtime failure on getImagePathFromUIImage

### DIFF
--- a/ios/MediaResponse.swift
+++ b/ios/MediaResponse.swift
@@ -99,7 +99,7 @@ func getThumbnail(from moviePath: String, in seconds: Double) -> String? {
         thumbnail = UIImage(cgImage: imgRef)
     }
     
-    let fullPath = getImagePathFromUIImage(uiImage: thumbnail!, prefix: "thumb")
+    let fullPath = thumbnail != nil ? getImagePathFromUIImage(uiImage: thumbnail!, prefix: "thumb") : nil
 
     return fullPath;
     


### PR DESCRIPTION
### Motivation:
When `thumbnail` is null (It happens in some videos), the following error message is displayed in the Xcode console: 
> Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value'.

### Solution:
This simple approach only checks that the thumbnail is not `nil` before calling the `getImagePathFromUIImage` method. There might be a better way to solve it, but this way fixes the issue.