### PR TITLE
fix Type mismatch openPicker using singleSelectedMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ Here are some related issues in the RN repo: [Issue 30202](https://github.com/fa
 See [options](#Options)
 
 ```js
-import { openPicker } from '@baronha/react-native-multiple-image-picker';
+import MultipleImagePicker from '@baronha/react-native-multiple-image-picker';
 // ...
-const response = await openPicker(options);
+const response = await MultipleImagePicker.openPicker(options);
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Here are some related issues in the RN repo: [Issue 30202](https://github.com/fa
 See [options](#Options)
 
 ```js
+import { openPicker } from '@baronha/react-native-multiple-image-picker';
+// ...
+const response = await openPicker(options);
+```
+
+### TypeScript
+
+```typescript
 import MultipleImagePicker from '@baronha/react-native-multiple-image-picker';
 // ...
 const response = await MultipleImagePicker.openPicker(options);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -93,16 +93,15 @@ interface MediaTypeResults {
   [MediaType.ALL]: ImageResults | VideoResults;
 }
 
-export type IOpenPicker = <T extends MediaType = MediaType.ALL>(
-  options: MultiPickerOptions & MediaTypeOptions[T] & Options<T>
-) => Promise<MediaTypeResults[T][]>;
-
 type MultipleImagePickerType = {
-  openPicker: IOpenPicker;
+  openPicker<T extends MediaType = MediaType.ALL>(
+    options: MultiPickerOptions & MediaTypeOptions[T] & Options<T>
+  ): Promise<MediaTypeResults[T][]>;
+  openPicker<T extends MediaType = MediaType.ALL>(
+    options: SinglePickerOptions & MediaTypeOptions[T] & Options<T>
+  ): Promise<MediaTypeResults[T]>;
 };
 
 const { MultipleImagePicker } = NativeModules;
-
-export const { openPicker } = MultipleImagePicker as MultipleImagePickerType;
 
 export default MultipleImagePicker as MultipleImagePickerType;


### PR DESCRIPTION
fix #131 

I fixed index.d.ts for TypeScript.

At project using TypeScript, types are correctly inferred  as shown in following VS Code screenshot.

|before|after|
| --- | --- |
|  ![ts-ng](https://github.com/baronha/react-native-multiple-image-picker/assets/296276/311c78b4-143a-4013-bd07-865c374c49b1)|  ![ts-ok](https://github.com/baronha/react-native-multiple-image-picker/assets/296276/b0b69f12-35ab-4d0d-acbe-8496e54c3c16)|

In addition, I added sample code for the TypeScript case to README.

|README|
| --- | 
| <img width="860" alt="fix-readme" src="https://github.com/baronha/react-native-multiple-image-picker/assets/296276/df12236d-62e9-449f-b719-c9e5786d4865">|


