### PR TITLE
fix Android exitAnimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ Thanks go to these wonderful people:
 	<tbody>
 		<tr>
             <td align="center">
+                <a href="https://github.com/cd-butterfly">
+                    <img src="https://avatars.githubusercontent.com/u/6622823?v=4" width="100;" alt="cd-butterfly"/>
+                    <br />
+                    <sub><b>cd-butterfly</b></sub>
+                </a>
+            </td>
+            <td align="center">
                 <a href="https://github.com/baronha">
                     <img src="https://avatars.githubusercontent.com/u/23580920?v=4" width="100;" alt="baronha"/>
                     <br />
@@ -258,6 +265,8 @@ Thanks go to these wonderful people:
                     <sub><b>Denis Bevilacqua</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/ctrleffive">
                     <img src="https://avatars.githubusercontent.com/u/35224957?v=4" width="100;" alt="ctrleffive"/>
@@ -265,8 +274,6 @@ Thanks go to these wonderful people:
                     <sub><b>Chandu J S</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/shafiqjefri">
                     <img src="https://avatars.githubusercontent.com/u/126740667?v=4" width="100;" alt="shafiqjefri"/>
@@ -300,13 +307,6 @@ Thanks go to these wonderful people:
                     <img src="https://avatars.githubusercontent.com/u/1430376?v=4" width="100;" alt="ouabing"/>
                     <br />
                     <sub><b>abing</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/cd-butterfly">
-                    <img src="https://avatars.githubusercontent.com/u/6622823?v=4" width="100;" alt="cd-butterfly"/>
-                    <br />
-                    <sub><b>cd-butterfly</b></sub>
                 </a>
             </td>
 		</tr>

--- a/android/src/main/java/com/reactnativemultipleimagepicker/MultipleImagePickerModule.kt
+++ b/android/src/main/java/com/reactnativemultipleimagepicker/MultipleImagePickerModule.kt
@@ -163,7 +163,7 @@ class MultipleImagePickerModule(reactContext: ReactApplicationContext) :
         // ANIMATION SLIDE FROM BOTTOM
         val animationStyle = PictureWindowAnimationStyle()
         animationStyle.setActivityEnterAnimation(com.luck.picture.lib.R.anim.ps_anim_up_in)
-        animationStyle.setActivityExitAnimation(com.luck.picture.lib.R.anim.ps_anim_up_in)
+        animationStyle.setActivityExitAnimation(com.luck.picture.lib.R.anim.ps_anim_down_out)
 
         // TITLE BAR
         val titleBar = TitleBarStyle()


### PR DESCRIPTION
https://github.com/baronha/react-native-multiple-image-picker/pull/156/files#diff-8c60d80b18ac4bd70c96d689373a709188dd0d6b8d8357deea48ddb1215aa1d8R166 
This commit might have been the result of a copy-paste error, leading to the Android exitAnimation changing from ps_anim_down_out to ps_anim_up_in。