### PR TITLE
fix: use tsconfig.build.json to build outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "tsc || exit 0;",
-    "typecheck": "tsc --noEmit",
+    "postinstall": "tsc --project tsconfig.build.json || exit 0;",
+    "typecheck": "tsc --project tsconfig.build.json --noEmit",
     "clean": "rm -rf android/build node_modules/**/android/build lib",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,7 @@
-
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example", "docs"],
+  "compilerOptions": {
+    "declaration": true
+  }
 }


### PR DESCRIPTION
## Bug fix 🐛

Thanks for great library. 🙌

This might fix this [issue](https://github.com/baronha/react-native-multiple-image-picker/issues/192)

Check outputs below. 

<img width="287" alt="Screenshot 2024-12-15 at 5 41 03 PM" src="https://github.com/user-attachments/assets/e209a529-6d90-41c9-8771-007a5eb35320" />

I'll make other pull request using [builder bob](https://callstack.github.io/react-native-builder-bob) if you prefer builder bob. 



