### PR TITLE
Fix for 3 Button navigation Hiding actionbar

### DIFF
--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Base.Theme.NoActionBar" parent="Theme.AppCompat.Light.NoActionBar" />
+    <style name="Base.Theme.NoActionBar" parent="Theme.AppCompat.Light.NoActionBar"> 
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
 
     <style name="Picture.Theme.Translucent" parent="Base.Theme.NoActionBar">
         <item name="android:windowBackground">@color/ps_color_transparent</item>


### PR DESCRIPTION
Actionbar on 3button navigation will now move above, and when using gesture navigation will remain as usual.