### PR TITLE
feat: Enable 16 KB page size on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
-                arguments "-DANDROID_STL=c++_shared"
+                arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 abiFilters(*reactNativeArchitectures())
             }
         }
@@ -139,6 +139,11 @@ dependencies {
     // exoplayer
     implementation "com.google.android.exoplayer:exoplayer:2.19.1"
 
+    def camerax_version = "1.5.2"
+    api "androidx.camera:camera-core:${camerax_version}"
+    api "androidx.camera:camera-camera2:${camerax_version}"
+    implementation "androidx.camera:camera-view:${camerax_version}"
+    implementation "androidx.camera:camera-lifecycle:${camerax_version}"
 
     implementation "com.facebook.react:react-native:+"
 
@@ -153,4 +158,3 @@ if (isNewArchitectureEnabled()) {
         codegenJavaPackageName = "com.margelo.nitro.multipleimagepicker"
     }
 }
-

--- a/example/app.json
+++ b/example/app.json
@@ -38,9 +38,9 @@
             "useFrameworks": "static"
           },
           "android": {
-            "compileSdkVersion": 34,
-            "targetSdkVersion": 34,
-            "buildToolsVersion": "34.0.0"
+            "compileSdkVersion": 35,
+            "targetSdkVersion": 35,
+            "buildToolsVersion": "35.0.0"
           }
         }
       ]

--- a/example/package.json
+++ b/example/package.json
@@ -30,7 +30,7 @@
     "@react-native/typescript-config": "0.75.2",
     "@types/react": "~19.1.10",
     "react-native-builder-bob": "^0.30.0",
-    "react-native-nitro-modules": "^0.25.2",
+    "react-native-nitro-modules": "^0.27.4",
     "typescript": "~5.9.2"
   },
   "private": true

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1264,11 +1264,6 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
-"@baronha/react-native-image-grid@^0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@baronha/react-native-image-grid/-/react-native-image-grid-0.2.7.tgz#a69df4d90605cf673a9f676bc4c0b7e95a38f0e7"
-  integrity sha512-F5q+hJ1p0+hfWYhOK4uL2EgseG89hpiMu0rMIaiw7lMpEA3sKC1AUOhOTKS58LeX1xE/XoqZ0P7tzyntKN+EoQ==
-
 "@expo/cli@54.0.18":
   version "54.0.18"
   resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-54.0.18.tgz#cd82a55bb7caa557d641d3bb4046b2dacf17ab61"
@@ -5382,10 +5377,10 @@ react-native-is-edge-to-edge@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz#64e10851abd9d176cbf2b40562f751622bde3358"
   integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
 
-react-native-nitro-modules@^0.25.2:
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/react-native-nitro-modules/-/react-native-nitro-modules-0.25.2.tgz#3d03869934854d7509c2f0dbaf4dca83d6969faf"
-  integrity sha512-rL+X0LzB8BXvpdrUE/+oZ5v4qS/1nZIq0M8Uctbvqq2q53sVCHX4995ffT8+lGIJe/f0QcBvvrEeXtBPl86iwQ==
+react-native-nitro-modules@^0.27.4:
+  version "0.27.6"
+  resolved "https://registry.yarnpkg.com/react-native-nitro-modules/-/react-native-nitro-modules-0.27.6.tgz#4a48c0945ca1b7ce36ef1a10c24236e6f17a1b3d"
+  integrity sha512-g8v+4njjOcS5t19dsVMveODsZ0CifIvYO3WMt/XUykta4sRlMYmM4rlHAykgIYWPOIrwWmz/GE8iK22PlbDFIA==
 
 react-native@0.81.5:
   version "0.81.5"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "typescript": "tsc --noEmit false",
     "specs": "bun run --filter=\"**\" typescript && bun nitro-codegen --logLevel=\"debug\"",
     "nitro": "yarn nitro-codegen",
-    "example": "yarn --cwd MultipleImagePickerExample",
-    "pod": "cd MultipleImagePickerExample && pod-install --quiet",
+    "example": "yarn --cwd example",
+    "pod": "cd example && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pod",
     "prepare": "bob build"
   },

--- a/package.json
+++ b/package.json
@@ -64,12 +64,12 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "nitro-codegen": "0.25.2",
+    "nitro-codegen": "0.27.4",
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-native": "^0.75.2",
     "react-native-builder-bob": "^0.30.0",
-    "react-native-nitro-modules": "0.25.2",
+    "react-native-nitro-modules": "0.27.4",
     "typescript": "^5.5.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4585,16 +4585,16 @@ neo-async@^2.5.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-nitro-codegen@0.25.2:
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/nitro-codegen/-/nitro-codegen-0.25.2.tgz#12a67606b52c18be4209cf9fbc08ae3cca9d4bcc"
-  integrity sha512-i0pGujdtmUaSmsawU6bmyFfW6MQbq+PZCWDT10QQg1EQbdPRvYAB5773R9GZtYoGNMGJ5qZVZUWnPBJRPOe61A==
+nitro-codegen@0.27.4:
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/nitro-codegen/-/nitro-codegen-0.27.4.tgz#e5b8f92e403d835dda1bca4f2f519c642bcf4b5d"
+  integrity sha512-VTuZpvTvOZNorkzrUOit/B+9FE5+G2XY4DjpmZOfJXm5LZSHllu2dnXS9FWj6+mWSg/uhM8/gdV2jsKcLki93w==
   dependencies:
     chalk "^5.3.0"
-    react-native-nitro-modules "^0.25.2"
+    react-native-nitro-modules "^0.27.4"
     ts-morph "^25.0.0"
     yargs "^17.7.2"
-    zod "^3.23.8"
+    zod "^4.0.5"
 
 nocache@^3.0.1:
   version "3.0.4"
@@ -5100,10 +5100,15 @@ react-native-builder-bob@^0.30.0:
     which "^2.0.2"
     yargs "^17.5.1"
 
-react-native-nitro-modules@0.25.2, react-native-nitro-modules@^0.25.2:
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/react-native-nitro-modules/-/react-native-nitro-modules-0.25.2.tgz#3d03869934854d7509c2f0dbaf4dca83d6969faf"
-  integrity sha512-rL+X0LzB8BXvpdrUE/+oZ5v4qS/1nZIq0M8Uctbvqq2q53sVCHX4995ffT8+lGIJe/f0QcBvvrEeXtBPl86iwQ==
+react-native-nitro-modules@0.27.4:
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/react-native-nitro-modules/-/react-native-nitro-modules-0.27.4.tgz#6420ed81de587e098196eb909cf1730444e2bb05"
+  integrity sha512-YCM39MzdYQD/rXUsP4U3JkhBbrFY5H4hokJBJx0v4QT5q11lHl7dNkE3sfEPSB/CCbPt6gmrKmL3O4ZTGH4p7Q==
+
+react-native-nitro-modules@^0.27.4:
+  version "0.27.6"
+  resolved "https://registry.yarnpkg.com/react-native-nitro-modules/-/react-native-nitro-modules-0.27.6.tgz#4a48c0945ca1b7ce36ef1a10c24236e6f17a1b3d"
+  integrity sha512-g8v+4njjOcS5t19dsVMveODsZ0CifIvYO3WMt/XUykta4sRlMYmM4rlHAykgIYWPOIrwWmz/GE8iK22PlbDFIA==
 
 react-native@^0.75.2:
   version "0.75.4"
@@ -6237,7 +6242,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.23.8:
-  version "3.24.1"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.1.tgz#27445c912738c8ad1e9de1bea0359fa44d9d35ee"
-  integrity sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==
+zod@^4.0.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.5.tgz#aeb269a6f9fc259b1212c348c7c5432aaa474d2a"
+  integrity sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==


### PR DESCRIPTION
- Enable 16 KB page size by following [guide](https://developer.android.com/guide/practices/page-sizes#compile-r27) (libMultiplelmagePicker.so)
- Force CameraX to version that supports 16 KB page size (libimage_processing_util_jni.so)
- Bump `react-native-nitro-modules` to version that supports 16 KB page size (libNitroModules.so)
- Bump SDK version to fix `style attribute 'android:attr/windowOptOutEdgeToEdgeEnforcement' not found`

Before
<img width="1355" height="747" alt="Screenshot 2026-01-07 at 4 27 25 PM" src="https://github.com/user-attachments/assets/b7a33c0f-393c-43c2-ad3c-25e5d04b097f" />

After
<img width="1355" height="747" alt="Screenshot 2026-01-08 at 8 51 02 AM" src="https://github.com/user-attachments/assets/9155a409-f267-4d4f-b029-ad1ec7f9220b" />
