### PR TITLE
Fixes Android preview broken state when pressing hardware back.

### DIFF
--- a/android/src/main/java/com/margelo/nitro/multipleimagepicker/MultipleImagePickerImp.kt
+++ b/android/src/main/java/com/margelo/nitro/multipleimagepicker/MultipleImagePickerImp.kt
@@ -334,7 +334,7 @@ class MultipleImagePickerImp(reactContext: ReactApplicationContext?) :
                     return true
                 }
             })
-            .startFragmentPreview(index, false, assets)
+            .startActivityPreview(index, false, assets)
     }
 
 


### PR DESCRIPTION
Problem:
When using startFragmentPreview, pressing Android hardware back while in full-screen preview
causes React Navigation to navigate back, but the native preview overlay remains visible.

Solution:
Replace startFragmentPreview with startActivityPreview to isolate preview in its own Activity.

Closes #254